### PR TITLE
event listener fixed to now correctly receive txlocks

### DIFF
--- a/src/views/Qr.vue
+++ b/src/views/Qr.vue
@@ -78,7 +78,7 @@ export default {
 
   sockets: {
     // listen for 'tx' event from insight
-    tx: function (data) {
+    txlock: function (data) {
       // bind 'this' for use inside the function
       let vm = this
       // check each address in vout


### PR DESCRIPTION
Fixed the evenlistener so that it now correctly returns txlocks from the updated insight api